### PR TITLE
Migrate preferences from old bundle store to new bundle store

### DIFF
--- a/org.eclipse.copilot.core/src/org/eclipse/copilot/core/CopilotCore.java
+++ b/org.eclipse.copilot.core/src/org/eclipse/copilot/core/CopilotCore.java
@@ -228,7 +228,7 @@ public class CopilotCore extends Plugin {
    */
   private void migratePrefFromLegacyPlugin() {
     IEclipsePreferences newPrefs = InstanceScope.INSTANCE.getNode("org.eclipse.copilot.ui");
-    if (newPrefs == null || newPrefs.getBoolean("hasMigratedOnChangeBundleName", false)) {
+    if (newPrefs == null || newPrefs.getBoolean("hasMigratedPrefFromLegacyPlugin", false)) {
       return;
     }
 
@@ -251,7 +251,7 @@ public class CopilotCore extends Plugin {
       }
 
       // Set migration flag
-      newPrefs.putBoolean("hasMigratedOnChangeBundleName", true);
+      newPrefs.putBoolean("hasMigratedPrefFromLegacyPlugin", true);
       newPrefs.flush();
     } catch (Exception e) {
       CopilotCore.LOGGER.error("Failed to migrate preferences", e);

--- a/org.eclipse.copilot.core/src/org/eclipse/copilot/core/CopilotCore.java
+++ b/org.eclipse.copilot.core/src/org/eclipse/copilot/core/CopilotCore.java
@@ -23,6 +23,8 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.LanguageServersRegistry;
@@ -75,6 +77,7 @@ public class CopilotCore extends Plugin {
 
   @Override
   public void start(BundleContext context) throws Exception {
+    migratePrefOnChangeBundleName();
     init(context);
   }
 
@@ -217,5 +220,41 @@ public class CopilotCore extends Plugin {
 
   public void setChatServiceManager(IChatServiceManager chatServiceManager) {
     this.chatServiceManager = chatServiceManager;
+  }
+
+  /**
+   * This method is called when the plugin is loaded to ensure that any preferences stored under the old bundle name are
+   * migrated to the new one.
+   */
+  private void migratePrefOnChangeBundleName() {
+    IEclipsePreferences newPrefs = InstanceScope.INSTANCE.getNode("org.eclipse.copilot.ui");
+    if (newPrefs == null || newPrefs.getBoolean("hasMigratedOnChangeBundleName", false)) {
+      return;
+    }
+
+    IEclipsePreferences oldPrefs = InstanceScope.INSTANCE.getNode("com.microsoft.copilot.eclipse.ui");
+    if (oldPrefs == null) {
+      return;
+    }
+
+    try {
+      String[] keys = oldPrefs.keys();
+      if (keys.length > 0) {
+        for (String key : keys) {
+          String value = oldPrefs.get(key, null);
+          if (value != null) {
+            newPrefs.put(key, value);
+          }
+        }
+
+        CopilotCore.LOGGER.info("Migrated " + keys.length + " preferences from previous bundle name");
+      }
+
+      // Set migration flag
+      newPrefs.putBoolean("hasMigratedOnChangeBundleName", true);
+      newPrefs.flush();
+    } catch (Exception e) {
+      CopilotCore.LOGGER.error("Failed to migrate preferences", e);
+    }
   }
 }

--- a/org.eclipse.copilot.core/src/org/eclipse/copilot/core/CopilotCore.java
+++ b/org.eclipse.copilot.core/src/org/eclipse/copilot/core/CopilotCore.java
@@ -62,7 +62,7 @@ public class CopilotCore extends Plugin {
    */
   public static final String INIT_JOB_FAMILY = "org.eclipse.copilot.core.initJob";
 
-  // TODO: Remove these 2 constant after several releases since the migration will be completed in next release.
+  // TODO: Remove these 2 constants after several releases since the migration will be completed in the next.
   private static final String LEGACY_PREF_NODE_NAME = "com.microsoft.copilot.eclipse.ui";
   private static final String HAS_MIGRATED_PREF_FROM_LEGACY_PLUGIN = "hasMigratedPrefFromLegacyPlugin";
 

--- a/org.eclipse.copilot.core/src/org/eclipse/copilot/core/CopilotCore.java
+++ b/org.eclipse.copilot.core/src/org/eclipse/copilot/core/CopilotCore.java
@@ -77,7 +77,7 @@ public class CopilotCore extends Plugin {
 
   @Override
   public void start(BundleContext context) throws Exception {
-    migratePrefOnChangeBundleName();
+    migratePrefFromLegacyPlugin();
     init(context);
   }
 
@@ -226,7 +226,7 @@ public class CopilotCore extends Plugin {
    * This method is called when the plugin is loaded to ensure that any preferences stored under the old bundle name are
    * migrated to the new one.
    */
-  private void migratePrefOnChangeBundleName() {
+  private void migratePrefFromLegacyPlugin() {
     IEclipsePreferences newPrefs = InstanceScope.INSTANCE.getNode("org.eclipse.copilot.ui");
     if (newPrefs == null || newPrefs.getBoolean("hasMigratedOnChangeBundleName", false)) {
       return;

--- a/org.eclipse.copilot.core/src/org/eclipse/copilot/core/CopilotCore.java
+++ b/org.eclipse.copilot.core/src/org/eclipse/copilot/core/CopilotCore.java
@@ -62,6 +62,10 @@ public class CopilotCore extends Plugin {
    */
   public static final String INIT_JOB_FAMILY = "org.eclipse.copilot.core.initJob";
 
+  // TODO: Remove these 2 constant after several releases since the migration will be completed in next release.
+  private static final String LEGACY_PREF_NODE_NAME = "com.microsoft.copilot.eclipse.ui";
+  private static final String HAS_MIGRATED_PREF_FROM_LEGACY_PLUGIN = "hasMigratedPrefFromLegacyPlugin";
+
   /**
    * Creates the Copilot core plugin. The plugin is created automatically by the Eclipse framework. Clients must not
    * call this constructor.
@@ -223,16 +227,17 @@ public class CopilotCore extends Plugin {
   }
 
   /**
-   * This method is called when the plugin is loaded to ensure that any preferences stored under the old bundle name are
-   * migrated to the new one.
+   * TODO: Remove this method after several releases since the migration will be completed in next release. This method
+   * is called when the plugin is loaded to ensure that any preferences stored under the old bundle name are migrated to
+   * the new one.
    */
   private void migratePrefFromLegacyPlugin() {
     IEclipsePreferences newPrefs = InstanceScope.INSTANCE.getNode("org.eclipse.copilot.ui");
-    if (newPrefs == null || newPrefs.getBoolean("hasMigratedPrefFromLegacyPlugin", false)) {
+    if (newPrefs == null || newPrefs.getBoolean(HAS_MIGRATED_PREF_FROM_LEGACY_PLUGIN, false)) {
       return;
     }
 
-    IEclipsePreferences oldPrefs = InstanceScope.INSTANCE.getNode("com.microsoft.copilot.eclipse.ui");
+    IEclipsePreferences oldPrefs = InstanceScope.INSTANCE.getNode(LEGACY_PREF_NODE_NAME);
     if (oldPrefs == null) {
       return;
     }
@@ -251,7 +256,7 @@ public class CopilotCore extends Plugin {
       }
 
       // Set migration flag
-      newPrefs.putBoolean("hasMigratedPrefFromLegacyPlugin", true);
+      newPrefs.putBoolean(HAS_MIGRATED_PREF_FROM_LEGACY_PLUGIN, true);
       newPrefs.flush();
     } catch (Exception e) {
       CopilotCore.LOGGER.error("Failed to migrate preferences", e);

--- a/org.eclipse.copilot.ui/src/org/eclipse/copilot/ui/preferences/LanguageServerSettingManager.java
+++ b/org.eclipse.copilot.ui/src/org/eclipse/copilot/ui/preferences/LanguageServerSettingManager.java
@@ -68,7 +68,6 @@ public class LanguageServerSettingManager implements IProxyChangeListener, IProp
     this.copilotLanguageServerConnection = conn;
     this.proxyService = proxyService;
     this.preferenceStore = preferenceStore;
-
     // add listeners
     proxyService.addProxyChangeListener(this);
     preferenceStore.addPropertyChangeListener(this);

--- a/org.eclipse.copilot.ui/src/org/eclipse/copilot/ui/preferences/LanguageServerSettingManager.java
+++ b/org.eclipse.copilot.ui/src/org/eclipse/copilot/ui/preferences/LanguageServerSettingManager.java
@@ -26,6 +26,8 @@ import org.eclipse.core.net.proxy.IProxyChangeEvent;
 import org.eclipse.core.net.proxy.IProxyChangeListener;
 import org.eclipse.core.net.proxy.IProxyData;
 import org.eclipse.core.net.proxy.IProxyService;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
@@ -68,6 +70,8 @@ public class LanguageServerSettingManager implements IProxyChangeListener, IProp
     this.copilotLanguageServerConnection = conn;
     this.proxyService = proxyService;
     this.preferenceStore = preferenceStore;
+    migratePrefOnChangeBundleName();
+
     // add listeners
     proxyService.addProxyChangeListener(this);
     preferenceStore.addPropertyChangeListener(this);
@@ -308,6 +312,42 @@ public class LanguageServerSettingManager implements IProxyChangeListener, IProp
     githubSettings.setWorkspaceCopilotInstructions(
         isEnabled ? preferenceStore.getString(Constants.CUSTOM_INSTRUCTIONS_WORKSPACE) : null);
     return new CopilotLanguageServerSettings(null, null, null, githubSettings);
+  }
+
+  /**
+   * This method is called when the plugin is loaded to ensure that any preferences stored under the old bundle name are
+   * migrated to the new one.
+   */
+  private void migratePrefOnChangeBundleName() {
+    IEclipsePreferences newPrefs = InstanceScope.INSTANCE.getNode("org.eclipse.copilot.ui");
+    if (newPrefs == null || newPrefs.getBoolean("hasMigratedOnChangeBundleName", false)) {
+      return;
+    }
+
+    IEclipsePreferences oldPrefs = InstanceScope.INSTANCE.getNode("com.microsoft.copilot.eclipse.ui");
+    if (oldPrefs == null) {
+      return;
+    }
+
+    try {
+      String[] keys = oldPrefs.keys();
+      if (keys.length > 0) {
+        for (String key : keys) {
+          String value = oldPrefs.get(key, null);
+          if (value != null) {
+            newPrefs.put(key, value);
+          }
+        }
+
+        CopilotCore.LOGGER.info("Migrated " + keys.length + " preferences from previous bundle name");
+      }
+
+      // Set migration flag
+      newPrefs.putBoolean("hasMigratedOnChangeBundleName", true);
+      newPrefs.flush();
+    } catch (Exception e) {
+      CopilotCore.LOGGER.error("Failed to migrate preferences", e);
+    }
   }
 
   /**


### PR DESCRIPTION
Add a preference store migration to make sure user don't lost their preference of the copilot plugin.

The bundle name will change from "com.microsoft.copilot.eclipse.ui" to "org.eclipse.copilot.ui" after opensource.
The preference store node name is same with bundle name, which will be changed together.
This preference migration will be applied once when first-time starting the new one.
