### PR TITLE
Produce source bundles and include them in the update site

### DIFF
--- a/org.eclipse.copilot.repository/pom.xml
+++ b/org.eclipse.copilot.repository/pom.xml
@@ -11,27 +11,16 @@
 	<packaging>eclipse-repository</packaging>
 	<name>${base.name} :: Repository</name>
 
-    <build>
-    <plugins>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-p2-director-plugin</artifactId>
-        <version>${tycho-version}</version>
-        <executions>
-          <execution>
-            <id>materialize-products</id>
-            <goals>
-              <goal>materialize-products</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>archive-products</id>
-            <goals>
-              <goal>archive-products</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<includeAllSources>true</includeAllSources>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<properties>
 		<base.name>GitHub Copilot</base.name>
-		<tycho-version>4.0.10</tycho-version>
+		<tycho-version>4.0.13</tycho-version>
 		<checkstyle-version>3.6.0</checkstyle-version>
 	</properties>
 
@@ -100,6 +100,24 @@
 						</environment>
 					</environments>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-source-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<archive>
+						<addMavenDescriptor>false</addMavenDescriptor>
+					</archive>
+				</configuration>
+				<executions>
+					<execution>
+						<id>plugin-source</id>
+						<goals>
+							<goal>plugin-source</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
- Use the latest Tycho release 4.0.13.
- Configure tycho-source-plugin for plugin-source goal.
- Configure tycho-p2-repository-plugin to include all sources.
- Remove tycho-p2-director-plugin because there is no product.