### PR TITLE
Clarify build instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,4 +49,7 @@ You can create a new `Eclipse Application` launch configuration for debugging pu
 The project uses Checkstyle to check for code format, Checkstyle rules can be found at `checkstyle.xml` at project root.
 
 ### Build
+
+The build requires the npm module installed [see setup](#setup).
+
 To build the plugin, run `./mvnw clean package`. The zip file can be found at `org.eclipse.copilot.repository/target/org.eclipse.copilot.repository-*.zip`


### PR DESCRIPTION
Adds link to the setup in the build section to ensure user knows about this requirement.

See also https://github.com/eclipse-copilot/eclipse-copilot/issues/26